### PR TITLE
fix for Keymaster indexOf error

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -218,7 +218,7 @@
     var tagName = el.tagName;
     var classList = el.classList;
 
-    if (! classList instanceof DOMTokenList) {
+    if (! (classList instanceof DOMTokenList)) {
       console.info('Element', el);
       throw new Error('Browser does not support classList');
     }

--- a/keymaster.js
+++ b/keymaster.js
@@ -211,13 +211,20 @@
       return _downKeys.slice(0);
   }
 
+  // different behavior from canonical repo to allow us to watch events on more
+  // element types
   function filter(event){
     var el = (event.target || event.srcElement);
     var tagName = el.tagName;
-    var className = el.className;
+    var classList = el.classList;
+
+    if (! classList instanceof DOMTokenList) {
+      console.info('Element', el);
+      throw new Error('Browser does not support classList');
+    }
 
     var hasAllowedTag = tagName !== 'INPUT' && tagName !== 'SELECT' && tagName !== 'TEXTAREA';
-    var hasAllowedClass = className && className.indexOf('js-keymaster-allow') >= 0;
+    var hasAllowedClass = classList.contains('js-keymaster-allow');
 
     return hasAllowedTag || hasAllowedClass;
   }


### PR DESCRIPTION
error in IE11 and Chrome 46:
https://rollbar.com/quizlet/Quizlet/items/109782/\?item_page\=0\&item_count\=100\&\#graphs

IE11 supports classList and we rely on it already in our code:
https://caniuse.com/\#feat\=classlist

This also makes a more informative alert in the event that `classList` isn't the type it needs to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quizlet/keymaster/2)
<!-- Reviewable:end -->
